### PR TITLE
Fix a typo.

### DIFF
--- a/deployments/server/templates/deployment.yaml
+++ b/deployments/server/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: file-manager-server
-        image: "{{ .Values.image.repository }}:{{ .Values.version | default (printf "server-%s" .Chart.Version) }}"
+        image: "{{ .Values.image.repository }}:{{ default .Chart.Version .Values.version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - run


### PR DESCRIPTION
File-manager does not need 'server-' prefix for version tag.