### PR TITLE
Remove unnecessary annotation for grpc

### DIFF
--- a/deployments/server/templates/service.yaml
+++ b/deployments/server/templates/service.yaml
@@ -22,8 +22,6 @@ metadata:
   name: {{ include "file-manager-server.fullname" . }}-grpc
   labels:
     {{- include "file-manager-server.labels" . | nindent 4 }}
-  annotations:
-    konghq.com/protocol: grpc
 spec:
   type: ClusterIP
   ports:
@@ -43,8 +41,6 @@ metadata:
   name: {{ include "file-manager-server.fullname" . }}-internal-grpc
   labels:
     {{- include "file-manager-server.labels" . | nindent 4 }}
-  annotations:
-    konghq.com/protocol: grpc
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
The annotation was no-op since gRPC requests are not routed by Kong.